### PR TITLE
Implement Get Usage Service

### DIFF
--- a/core/apps/service.go
+++ b/core/apps/service.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -20,6 +21,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ipfs/go-datastore"
 	p2phost "github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -35,6 +37,7 @@ var log = logrus.New().WithField("service", "apps")
 
 const NAMESPACE = "subnet-apps"
 const PROTOCOL_ID = protocol.ID("subnet-apps")
+const RESOURCE_USAGE_KEY = "resource-usage"
 
 type Service struct {
 	peerId            peer.ID
@@ -50,13 +53,15 @@ type Service struct {
 	subnetAppRegistry *SubnetAppRegistry
 	subnetRegistry    *SubnetRegistry
 	accountService    *account.AccountService
+	Datastore         datastore.Datastore // Datastore for storing resource usage
 }
 
 // Initializes the Service with Ethereum and containerd clients.
-func New(cfg *config.C, P2P *p2p.P2P) *Service {
+func New(cfg *config.C, P2P *p2p.P2P, dataStore datastore.Datastore) *Service {
 	return &Service{
 		P2P:        P2P,
 		cfg:        cfg,
+		Datastore:  dataStore,
 		IsProvider: cfg.GetBool("provider.enable", false),
 		stopChan:   make(chan struct{}),
 	}
@@ -77,6 +82,11 @@ func (s *Service) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	peerId := s.cfg.GetString("identity.peer_id", "")
+	if peerId != "" {
+		s.peerId = peer.ID(peerId)
 	}
 
 	// Register the P2P protocol for signing
@@ -114,6 +124,11 @@ func (s *Service) Start(ctx context.Context) error {
 
 		if err != nil {
 			return fmt.Errorf("error connecting to containerd: %v", err)
+		}
+
+		var defaultSubnetID = big.NewInt(0)
+		if defaultSubnetID.Cmp(subnetID) == 0 {
+			return fmt.Errorf("PeerID is not registered for any SubnetID. Please register first")
 		}
 
 		s.subnetID = *subnetID
@@ -482,6 +497,53 @@ func (s *Service) RegisterSignProtocol() error {
 // 	return int64(duration), nil // Return duration in seconds
 // }
 
+// func (s *Service) RegisterNode(ctx context.Context, appId *big.Int) (common.Hash, error) {
+// 	// Get the nonce for the account
+// 	fromAddress := crypto.PubkeyToAddress(s.privKey.PublicKey)
+// 	nonce, err := s.ethClient.PendingNonceAt(ctx, fromAddress)
+// 	if err != nil {
+// 		return common.Hash{}, fmt.Errorf("failed to get account nonce: %w", err)
+// 	}
+// 	// Get the suggested gas price
+// 	gasPrice, err := s.ethClient.SuggestGasPrice(ctx)
+// 	if err != nil {
+// 		return common.Hash{}, fmt.Errorf("failed to get suggested gas price: %w", err)
+// 	}
+// 	toAddress := common.HexToAddress(s.cfg.GetString("apps.subnet_app_registry_contract", config.DefaultSubnetAppRegistryContract))
+// 	// Estimate the gas limit
+// 	msg := ethereum.CallMsg{
+// 		From: fromAddress,
+// 		To:   &toAddress,
+// 	}
+// 	gasLimit, err := s.ethClient.EstimateGas(ctx, msg)
+// 	if err != nil {
+// 		return common.Hash{}, fmt.Errorf("failed to estimate gas: %w", err)
+// 	}
+// 	// Sign the transaction
+// 	chainID, err := s.ethClient.NetworkID(ctx)
+// 	if err != nil {
+// 		return common.Hash{}, fmt.Errorf("failed to get chain ID: %w", err)
+// 	}
+// 	signFn := func(from common.Address, rawTx *types.Transaction) (*types.Transaction, error) {
+// 		signedTx, err := types.SignTx(rawTx, types.NewEIP155Signer(chainID), s.privKey)
+// 		return signedTx, err
+// 	}
+// 	opt := bind.TransactOpts{
+// 		From:     fromAddress,
+// 		Nonce:    big.NewInt(int64(nonce)),
+// 		Value:    big.NewInt(0),
+// 		GasPrice: gasPrice,
+// 		GasLimit: gasLimit,
+// 		Context:  ctx,
+// 		Signer:   signFn,
+// 	}
+// 	tx, err := s.subnetAppRegistry.RegisterNode(&opt, &s.subnetID, appId)
+// 	if err != nil {
+// 		return common.Hash{}, err
+// 	}
+// 	return tx.Hash(), nil
+// }
+
 func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage, error) {
 	// Load the container
 	ctx = namespaces.WithNamespace(ctx, NAMESPACE)
@@ -494,7 +556,21 @@ func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 	// Get the task
 	task, err := container.Task(ctx, nil)
 	if err != nil {
+		if errdefs.IsNotFound(err) {
+			// No task found; container is likely shut down
+			return s.getUsageFromExternal(ctx, appId)
+		}
 		return nil, fmt.Errorf("failed to get task for container: %w", err)
+	}
+
+	status, err := s.GetContainerStatus(ctx, appId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container status: %w", err)
+	}
+	if status != Running {
+		// Unable to get current container's metrics
+		// Get usage from external instead
+		s.getUsageFromExternal(ctx, appId)
 	}
 
 	// Get metrics
@@ -537,6 +613,23 @@ func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 		totalTxBytes += stat.BytesSent
 	}
 
+	// Get used storage
+	var storageBytes int64 = 0
+	info, err := container.Info(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container info: %v", err)
+	}
+	snapshotKey := info.SnapshotKey
+	snapshotService := s.containerdClient.SnapshotService(info.Snapshotter)
+	snapshotUsage, err := snapshotService.Usage(ctx, snapshotKey)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("snapshot %s not found: %v", snapshotKey, err)
+		}
+		return nil, fmt.Errorf("failed to get snapshot usage: %v", err)
+	}
+	storageBytes = snapshotUsage.Size
+
 	createTime, err := proc.CreateTime()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get process create time: %w", err)
@@ -553,7 +646,7 @@ func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 		UsedUploadBytes:   big.NewInt(int64(totalRxBytes)), // Set if applicable
 		UsedDownloadBytes: big.NewInt(int64(totalTxBytes)), // Set if applicable
 		Duration:          big.NewInt(durationSeconds),     // Calculate or set duration if available
-		UsedStorage:       big.NewInt(0),
+		UsedStorage:       big.NewInt(storageBytes),
 	}
 	switch metrics := data.(type) {
 	case *v1.Metrics:
@@ -574,8 +667,40 @@ func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 	// usage.Duration = calculateDurationBasedOnMetrics(metrics)
 
 	return usage, nil
-
 }
+
+func (s *Service) getUsageFromExternal(ctx context.Context, appId *big.Int) (*ResourceUsage, error) {
+	// Get usage from datastore
+	resourceUsageKey := datastore.NewKey(fmt.Sprintf("%s-%s", RESOURCE_USAGE_KEY, appId.String()))
+	updatedJsonData, err := s.Datastore.Get(ctx, resourceUsageKey)
+	if err == nil { // If the record exists in the datastore
+		var updatedData ResourceUsage
+		if err := json.Unmarshal(updatedJsonData, &updatedData); err == nil {
+			return &updatedData, nil
+		}
+	}
+
+	// No record found from datastore
+	// Get usage from smart contract
+	usage, err := s.subnetAppRegistry.GetAppNode(nil, appId, &s.subnetID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource usage from smart contract for appId %s: %v", appId.String(), err)
+	}
+
+	return convertToResourceUsage(usage, appId, &s.subnetID), nil
+}
+
+// func (s *Service) updateUsage(ctx context.Context, appId *big.Int, usage *ResourceUsage) error {
+// 	resourceUsageData, err := json.Marshal(usage)
+// 	if err != nil {
+// 		return fmt.Errorf("failed to marshal resource usage for appId %s: %v", appId.String(), err)
+// 	}
+// 	resourceUsageKey := datastore.NewKey(fmt.Sprintf("%s-%s", RESOURCE_USAGE_KEY, appId.String()))
+// 	if err := s.Datastore.Put(ctx, resourceUsageKey, resourceUsageData); err != nil {
+// 		return fmt.Errorf("failed to update resource usage for appId %s: %v", appId.String(), err)
+// 	}
+// 	return nil
+// }
 
 // // GetAppNode retrieves the details of an AppNode by its ID or similar identifier.
 // func (s *Service) GetAppNode(ctx context.Context, appId big.Int, subnetId big.Int) (ResourceUsage, error) {
@@ -671,5 +796,5 @@ func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 // }
 
 func (s *Service) GetSubnetIDFromPeerID(ctx context.Context) (*big.Int, error) {
-	return s.subnetRegistry.PeerToSubnet(nil, s.peerId.String())
+	return s.subnetRegistry.PeerToSubnet(nil, string(s.peerId))
 }

--- a/core/apps/types.go
+++ b/core/apps/types.go
@@ -157,3 +157,17 @@ func convertToApp(subnetApp SubnetAppRegistryApp, id *big.Int, status ProcessSta
 		Metadata:             metadata,
 	}
 }
+
+func convertToResourceUsage(usage SubnetAppRegistryAppNode, appId *big.Int, subnetId *big.Int) *ResourceUsage {
+	return &ResourceUsage{
+		AppId:             appId,
+		SubnetId:          subnetId,
+		UsedCpu:           usage.UsedCpu,
+		UsedGpu:           usage.UsedGpu,
+		UsedMemory:        usage.UsedMemory,
+		UsedStorage:       usage.UsedStorage,
+		UsedUploadBytes:   usage.UsedUploadBytes,
+		UsedDownloadBytes: usage.UsedDownloadBytes,
+		Duration:          usage.Duration,
+	}
+}

--- a/core/node/apps.go
+++ b/core/node/apps.go
@@ -3,14 +3,15 @@ package node
 import (
 	"context"
 
+	"github.com/ipfs/go-datastore"
 	"github.com/unicornultrafoundation/subnet-node/config"
 	"github.com/unicornultrafoundation/subnet-node/core/apps"
 	"github.com/unicornultrafoundation/subnet-node/p2p"
 	"go.uber.org/fx"
 )
 
-func AppService(lc fx.Lifecycle, cfg *config.C, P2P *p2p.P2P) *apps.Service {
-	srv := apps.New(cfg, P2P)
+func AppService(lc fx.Lifecycle, cfg *config.C, P2P *p2p.P2P, dataStore datastore.Datastore) *apps.Service {
+	srv := apps.New(cfg, P2P, dataStore)
 	lc.Append(fx.Hook{
 		OnStop: func(ctx context.Context) error {
 			return srv.Stop(ctx)


### PR DESCRIPTION
This merge request introduces a comprehensive implementation of the `Get Usage Service` for tracking resource used by a specific `appId` in the subnet system.

### Enhancements:  
- Add tracking storage used by a container
- Get usage from `Datastore`/Smart contract
- Correct retrieving `PeerId` from config file
- Prevent starting the Node with `PeerId` not registered to any `SubnetId`

### Next Steps:  
- Add support for update latest usage into `Datastore`
- Integrate automated tests for app lifecycle scenarios.  

### Notes:  
- The service is designed to align with the existing subnet node architecture and leverages `containerd` and `go-ethereum` libraries for container and Ethereum operations.  

Please review the implementation and provide feedback or suggestions for improvements. 