### PR TITLE
Cache resource usage data

### DIFF
--- a/core/apps/claim_reward.go
+++ b/core/apps/claim_reward.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *Service) startRewardClaimer(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Hour) // Đặt thời gian định kỳ là 1 giờ
+	ticker := time.NewTicker(1 * time.Hour)
 	defer ticker.Stop()
 
 	for {
@@ -88,6 +88,7 @@ func (s *Service) ClaimRewardsForAllRunningContainers(ctx context.Context) {
 			log.Errorf("Failed to claim reward for container %s: %v", containerId, err)
 		} else {
 			log.Infof("Reward claimed successfully for container %s, transaction hash: %s", containerId, txHash.Hex())
+			s.usageService.finalizeUsages(usage)
 		}
 	}
 }

--- a/core/apps/resource_usage.go
+++ b/core/apps/resource_usage.go
@@ -5,36 +5,76 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/errdefs"
 	"github.com/containerd/typeurl/v2"
-	"github.com/gogo/protobuf/proto"
-	"github.com/ipfs/go-datastore"
 	"github.com/shirou/gopsutil/process"
+	"github.com/unicornultrafoundation/subnet-node/common/networkutil"
+	"github.com/unicornultrafoundation/subnet-node/core/account"
 	pbapp "github.com/unicornultrafoundation/subnet-node/proto/subnet/app"
 )
 
-func (s *Service) startMonitoringUsage(ctx context.Context) {
+type UsageEntry = ResourceUsage
+type UsageMetadata = pbapp.ResourceUsageMetadata
+
+// UsageService tracks the resource usage for multiple containers.
+type UsageService struct {
+	accountService      *account.AccountService
+	mu                  sync.Mutex
+	entries             map[string]*UsageEntry
+	finalUsages         map[string]*UsageEntry
+	containerdClient    *containerd.Client
+	containerToMetadata map[string]*UsageMetadata
+	stopChan            chan struct{}
+}
+
+// NewUsages creates a new UsageService instance.
+func NewUsages(containerdClient *containerd.Client, accountService *account.AccountService) *UsageService {
+	return &UsageService{
+		accountService:      accountService,
+		entries:             make(map[string]*UsageEntry),
+		finalUsages:         make(map[string]*UsageEntry),
+		containerdClient:    containerdClient,
+		stopChan:            make(chan struct{}),
+		containerToMetadata: make(map[string]*UsageMetadata),
+	}
+}
+
+// Start starts the UsageService and periodically updates usages for all running containers.
+func (s *UsageService) Start(ctx context.Context) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-ctx.Done(): // Exit if the context is cancelled
+		case <-s.stopChan: // Exit if the stop channel is closed
 			return
-		case <-ticker.C: // On every tick, update all latest running containers's resource usages
+		case <-ticker.C: // On every tick, update resource usages for all running containers
 			s.updateAllRunningContainersUsage(ctx)
 		}
 	}
 }
 
-func (s *Service) GetUsage(ctx context.Context, appId *big.Int) (*ResourceUsage, error) {
-	return s.getUsageFromExternal(ctx, appId)
+// Stop stops the UsageService.
+func (s *UsageService) Stop() {
+	close(s.stopChan)
+	s.ClearUsageData()
+}
+
+// ClearUsageData clears all usage data.
+func (s *UsageService) ClearUsageData() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries = make(map[string]*UsageEntry)
+	s.finalUsages = make(map[string]*UsageEntry)
+	s.containerToMetadata = make(map[string]*UsageMetadata)
 }
 
 func (s *Service) GetAllRunningContainersUsage(ctx context.Context) (*ResourceUsage, error) {
@@ -97,7 +137,7 @@ func (s *Service) GetAllRunningContainersUsage(ctx context.Context) (*ResourceUs
 	return totalUsage, nil
 }
 
-func (s *Service) updateAllRunningContainersUsage(ctx context.Context) error {
+func (s *UsageService) updateAllRunningContainersUsage(ctx context.Context) error {
 	// Set the namespace for the containers
 	ctx = namespaces.WithNamespace(ctx, NAMESPACE)
 
@@ -117,7 +157,7 @@ func (s *Service) updateAllRunningContainersUsage(ctx context.Context) error {
 			return err
 		}
 
-		usage, pid, err := s.getUsage(ctx, appId)
+		usage, pid, err := s.getUsageFromContainer(ctx, appId)
 		if err != nil {
 			return fmt.Errorf("failed to get latest resource usage for appId %s: %v", appId.String(), err)
 		}
@@ -127,25 +167,21 @@ func (s *Service) updateAllRunningContainersUsage(ctx context.Context) error {
 		}
 
 		// Update usage metadata if the pid is new for appId
-		err = s.syncUsageMetadata(ctx, appId, *pid)
-		if err != nil {
-			return fmt.Errorf("failed to sync pid %d for appId %s: %v", *pid, appId.String(), err)
-		}
-		err = s.updateUsage(ctx, appId, *pid, usage)
-
-		if err != nil {
-			return fmt.Errorf("failed to update resource usage for container %s: %w", containerId, err)
-		}
+		s.syncUsageMetadata(appId, *pid)
+		s.mu.Lock()
+		s.updateUsage(appId, *pid, usage)
+		s.mu.Unlock()
 	}
 
 	return nil
 }
 
 // Get directly resource usage from container
-func (s *Service) getUsage(ctx context.Context, appId *big.Int) (*ResourceUsage, *uint32, error) {
-	// Load the container
+func (s *UsageService) getUsageFromContainer(ctx context.Context, appId *big.Int) (*ResourceUsage, *uint32, error) {
 	ctx = namespaces.WithNamespace(ctx, NAMESPACE)
 	app := App{ID: appId}
+
+	// Load the container
 	container, err := s.containerdClient.LoadContainer(ctx, app.ContainerId())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load container: %w", err)
@@ -157,12 +193,43 @@ func (s *Service) getUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 		return nil, nil, fmt.Errorf("failed to get task for container: %w", err)
 	}
 
+	// Get the process
+	pid := task.Pid()
+	proc, err := process.NewProcess(int32(pid))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get network I/O counters
+	netIO, err := proc.NetIOCounters(false)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Detect the network interfaces connected to the internet
+	internetInterfaces, err := networkutil.DetectInternetInterfaces()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to detect internet interfaces: %v", err)
+	}
+
+	// Calculate total received and transmitted bytes
+	var totalRxBytes, totalTxBytes uint64
+	for _, stat := range netIO {
+		for _, iface := range internetInterfaces {
+			if stat.Name == iface {
+				totalRxBytes += stat.BytesRecv
+				totalTxBytes += stat.BytesSent
+			}
+		}
+	}
+
 	// Get metrics
 	metric, err := task.Metrics(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get metrics: %w", err)
 	}
 
+	// Unmarshal metrics data
 	var data interface{}
 	switch {
 	case typeurl.Is(metric.Data, (*v1.Metrics)(nil)):
@@ -178,89 +245,66 @@ func (s *Service) getUsage(ctx context.Context, appId *big.Int) (*ResourceUsage,
 		return nil, nil, err
 	}
 
-	// Lấy thông tin Network I/O theo PID
-	pid := task.Pid()
-	proc, err := process.NewProcess(int32(pid))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var totalRxBytes uint64 = 0
-	var totalTxBytes uint64 = 0
-	netIO, err := proc.NetIOCounters(false)
-
-	if err != nil {
-		return nil, nil, err
-	}
-
-	for _, stat := range netIO {
-		totalRxBytes += stat.BytesRecv
-		totalTxBytes += stat.BytesSent
+	// Extract CPU and memory usage
+	var usedCpu, usedMemory uint64
+	switch metrics := data.(type) {
+	case *v1.Metrics:
+		usedCpu = metrics.CPU.Usage.Total
+		usedMemory = metrics.Memory.Usage.Usage
+	case *v2.Metrics:
+		usedCpu = metrics.CPU.UsageUsec
+		usedMemory = metrics.Memory.Usage
+	case *wstats.Statistics:
+		usedCpu = metrics.GetWindows().Processor.TotalRuntimeNS
+		usedMemory = metrics.GetWindows().Memory.MemoryUsageCommitBytes
+	default:
+		return nil, nil, fmt.Errorf("unsupported metrics type")
 	}
 
 	// Get used storage
-	var storageBytes int64 = 0
+	var storageBytes int64
 	info, err := container.Info(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get container info: %v", err)
 	}
-	snapshotKey := info.SnapshotKey
-	snapshotService := s.containerdClient.SnapshotService(info.Snapshotter)
-	snapshotUsage, err := snapshotService.Usage(ctx, snapshotKey)
+	snapshotUsage, err := s.containerdClient.SnapshotService(info.Snapshotter).Usage(ctx, info.SnapshotKey)
 	if err != nil {
-		if errdefs.IsNotFound(err) {
-			return nil, nil, fmt.Errorf("snapshot %s not found: %v", snapshotKey, err)
-		}
 		return nil, nil, fmt.Errorf("failed to get snapshot usage: %v", err)
 	}
 	storageBytes = snapshotUsage.Size
 
+	// Get duration of the pid running this app
 	createTime, err := proc.CreateTime()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get process create time: %w", err)
 	}
-
 	now := time.Now().UnixMilli()
-
 	duration := now - createTime
 	durationSeconds := duration / 1000
 
 	// Extract resource usage details from the metrics
 	usage := &ResourceUsage{
 		AppId:             appId,
+		UsedCpu:           big.NewInt(int64(usedCpu)),
+		UsedMemory:        big.NewInt(int64(usedMemory)),
 		UsedUploadBytes:   big.NewInt(int64(totalRxBytes)), // Set if applicable
 		UsedDownloadBytes: big.NewInt(int64(totalTxBytes)), // Set if applicable
-		Duration:          big.NewInt(durationSeconds),     // Calculate or set duration if available
 		UsedStorage:       big.NewInt(storageBytes),
+		Duration:          big.NewInt(durationSeconds), // Calculate or set duration if available
 	}
-	switch metrics := data.(type) {
-	case *v1.Metrics:
-		usage.UsedCpu = big.NewInt(int64(metrics.CPU.Usage.Total))
-		usage.UsedMemory = big.NewInt(int64(metrics.Memory.Usage.Usage))
-	case *v2.Metrics:
-		usage.UsedCpu = big.NewInt(int64(metrics.CPU.UsageUsec))
-		usage.UsedMemory = big.NewInt(int64(metrics.Memory.Usage))
-	case *wstats.Statistics:
-		usage.UsedCpu = big.NewInt(int64(metrics.GetWindows().Processor.TotalRuntimeNS))
-		usage.UsedMemory = big.NewInt(int64(metrics.GetWindows().Memory.MemoryUsageCommitBytes))
-	default:
-		return nil, nil, errors.New("unsupported metrics type")
-	}
-
-	// Optionally, calculate or set the duration if metrics provide a timestamp
-	// For example:
-	// usage.Duration = calculateDurationBasedOnMetrics(metrics)
 
 	return usage, &pid, nil
 }
 
-func (s *Service) getUsageFromExternal(ctx context.Context, appId *big.Int) (*ResourceUsage, error) {
+func (s *UsageService) getUsageFromExternal(appId *big.Int) (*ResourceUsage, error) {
 	providerId := big.NewInt(s.accountService.ProviderID())
-	// Get usage from datastore first
+
+	// Get usage from memory first
 	// Get all pids had run the appId from usage metadata
-	usageMetadata, err := s.getUsageMetadata(ctx, appId)
-	if err == nil {
-		// Some records exist in the datastore
+	s.mu.Lock()
+	usageMetadata, hasUsageMetadata := s.getUsageMetadata(appId)
+	if hasUsageMetadata {
+		// Some records exist in the memory
 		// Get all usages of the appId
 		totalUsage := &ResourceUsage{
 			AppId:             appId,
@@ -276,9 +320,10 @@ func (s *Service) getUsageFromExternal(ctx context.Context, appId *big.Int) (*Re
 
 		totalStorageRecord := big.NewInt(0)
 		for index, pid := range usageMetadata.Pids {
-			usage, err := s.getUsageFromStorage(ctx, appId, pid)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get resource usage from datastore for appId %s - pid %d: %v", appId.String(), pid, err)
+			usage, hasUsage := s.getUsage(appId, pid)
+			if !hasUsage {
+				s.mu.Unlock()
+				return nil, fmt.Errorf("failed to get resource usage from memory for appId %s - pid %d: usage should not exist", appId.String(), pid)
 			}
 			usage = fillDefaultResourceUsage(usage)
 
@@ -289,14 +334,13 @@ func (s *Service) getUsageFromExternal(ctx context.Context, appId *big.Int) (*Re
 			totalUsage.UsedDownloadBytes.Add(totalUsage.UsedDownloadBytes, usage.UsedDownloadBytes)
 			totalUsage.Duration.Add(totalUsage.Duration, usage.Duration)
 
-			if index < 5 {
-				// Only retrieve used memory/storage from <= 5 latest pid
+			if index < 5 { // Only retrieve used memory/storage from <= 5 latest pid
 				totalUsage.UsedMemory.Add(totalUsage.UsedMemory, usage.UsedMemory)
 				totalUsage.UsedStorage.Add(totalUsage.UsedStorage, usage.UsedStorage)
-
 				totalStorageRecord.Add(totalStorageRecord, big.NewInt(1))
 			}
 		}
+		s.mu.Unlock()
 
 		// Get average used memory/storage from <= 5 latest pid
 		totalUsage.UsedMemory.Div(totalUsage.UsedMemory, totalStorageRecord)
@@ -305,139 +349,111 @@ func (s *Service) getUsageFromExternal(ctx context.Context, appId *big.Int) (*Re
 		return totalUsage, nil
 	}
 
-	// No record found from datastore
+	// Try get usage from last finalized record
+	cachedFinalUsage, exist := s.finalUsages[appId.String()]
+	s.mu.Unlock()
+	if exist {
+		return cachedFinalUsage, nil
+	}
+
+	// No record found from memory
 	// Get usage from smart contract
-	usage, err := s.accountService.AppStore().GetDeployment(nil, appId, &s.subnetID)
+	usage, err := s.accountService.AppStore().GetDeployment(nil, appId, providerId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get resource usage from datastore & smart contract for appId %s:%s %v", appId.String(), s.subnetID.String(), err)
+		return nil, fmt.Errorf("failed to get resource usage from cache & smart contract for appId %s, providerId %s: %v", appId.String(), providerId.String(), err)
 	}
 
-	return convertToResourceUsage(usage, appId, &s.subnetID), nil
-}
-
-// Get resource usage created by a specific pid for appId from datastore
-func (s *Service) getUsageFromStorage(ctx context.Context, appId *big.Int, pid uint32) (*ResourceUsage, error) {
-	resourceUsageKey := getUsageKey(appId, pid)
-	usageData, err := s.Datastore.Get(ctx, resourceUsageKey)
-
-	if err == nil { // If the record exists in the datastore
-		var usage pbapp.ResourceUsageV2
-		if err := proto.Unmarshal(usageData, &usage); err == nil {
-			return convertUsageFromProto(usage), nil
-		}
-	}
-
-	return nil, fmt.Errorf("failed to get resource usage from datastore for appId %s: %v", appId.String(), err)
-}
-
-// Update resource usage created by a specific pid for appId to datastore
-func (s *Service) updateUsage(ctx context.Context, appId *big.Int, pid uint32, usage *ResourceUsage) error {
-	resourceUsageData, err := proto.Marshal(convertUsageToProto(*usage))
-	if err != nil {
-		return fmt.Errorf("failed to marshal resource usage for appId %s: %v", appId.String(), err)
-	}
-
-	resourceUsageKey := getUsageKey(appId, pid)
-	if err := s.Datastore.Put(ctx, resourceUsageKey, resourceUsageData); err != nil {
-		return fmt.Errorf("failed to update resource usage for appId %s: %v", appId.String(), err)
-	}
-	return nil
-}
-
-// Get resource usage info of an appId
-func (s *Service) getUsageMetadata(ctx context.Context, appId *big.Int) (*pbapp.ResourceUsageMetadata, error) {
-	usageMetadataKey := getUsageMetadataKey(appId)
-	usageMetadataBytes, err := s.Datastore.Get(ctx, usageMetadataKey)
-	if err != nil {
-		return nil, err
-	}
-
-	var usageMetadata pbapp.ResourceUsageMetadata
-	err = proto.Unmarshal(usageMetadataBytes, &usageMetadata)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal usage metadata for appId %s: %w", appId.String(), err)
-	}
-
-	return &usageMetadata, nil
-}
-
-// Update resource usage info of an appId
-func (s *Service) updateUsageMetadata(ctx context.Context, appId *big.Int, usageMetadata *pbapp.ResourceUsageMetadata) error {
-	usageMetadataBytes, err := proto.Marshal(usageMetadata)
-	if err != nil {
-		return fmt.Errorf("failed to marshal usage metadata for appId %s: %v", appId.String(), err)
-	}
-
-	usageMetadataKey := getUsageMetadataKey(appId)
-	if err := s.Datastore.Put(ctx, usageMetadataKey, usageMetadataBytes); err != nil {
-		return fmt.Errorf("failed to update usage metadata for appId %s: %v", appId.String(), err)
-	}
-
-	return nil
+	return convertToResourceUsage(usage, appId, providerId), nil
 }
 
 // Add new pid into usage metadata if it hadn't run appId before
-func (s *Service) syncUsageMetadata(ctx context.Context, appId *big.Int, pid uint32) error {
-	hasPid, err := s.hasUsage(ctx, appId, pid)
-	if err != nil {
-		return fmt.Errorf("failed to check pid for appId %s: %w", appId.String(), err)
-	}
+func (s *UsageService) syncUsageMetadata(appId *big.Int, pid uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, hasUsage := s.getUsage(appId, pid)
 
-	if hasPid {
-		return nil
-	}
-
-	hasUsageMetadata, err := s.hasUsageMetadata(ctx, appId)
-	if err != nil {
-		return fmt.Errorf("failed to check usage metadata for appId %s: %w", appId.String(), err)
+	if hasUsage {
+		return
 	}
 
 	usageMetadata := &pbapp.ResourceUsageMetadata{
 		Pids: *new([]uint32),
 	}
+	existingUsageMetadata, hasUsageMetadata := s.getUsageMetadata(appId)
+
 	if hasUsageMetadata {
-		usageMetadata, err = s.getUsageMetadata(ctx, appId)
-		if err != nil {
-			return fmt.Errorf("failed to get pidList for appId %s: %w", appId.String(), err)
-		}
+		usageMetadata = existingUsageMetadata
 	}
 
 	// Append new pid on the top of `Pids` list
 	usageMetadata.Pids = append([]uint32{pid}, usageMetadata.Pids...)
 
-	return s.updateUsageMetadata(ctx, appId, usageMetadata)
+	s.updateUsageMetadata(appId, usageMetadata)
 }
 
-// Get key to retrieve resource usage from datastore created by a pid which had run appId
-func getUsageKey(appId *big.Int, pid uint32) datastore.Key {
-	return datastore.NewKey(fmt.Sprintf("%s-%s-%d", RESOURCE_USAGE_KEY, appId.String(), pid))
-}
+// FinalizeUsages finalizes a given usage after being submitted to smart contract
+func (s *UsageService) finalizeUsages(usage *ResourceUsage) error {
+	appId := usage.AppId
 
-// Check if a pid creating resource usage of an `appId` has existed or not
-func (s *Service) hasUsage(ctx context.Context, appId *big.Int, pid uint32) (bool, error) {
-	resourceUsageKey := getUsageKey(appId, pid)
-	hasUsage, err := s.Datastore.Has(ctx, resourceUsageKey)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Save latest submitted usage data
+	s.finalUsages[appId.String()] = usage
 
-	if err != nil {
-		return false, fmt.Errorf("failed to check resource usage for appId %s: %w", appId.String(), err)
+	// Clear previous resource usage cached data
+	usageMetadata, hasUsageMetadata := s.getUsageMetadata(appId)
+	if !hasUsageMetadata {
+		return fmt.Errorf("resource usage metadata not found for appID: %s", appId)
 	}
 
-	return hasUsage, nil
+	for _, pid := range usageMetadata.Pids {
+		_, hasUsage := s.getUsage(appId, pid)
+		if !hasUsage {
+			return fmt.Errorf("failed to get resource usage from memory for appId %s - pid %d: usage should not exist", appId.String(), pid)
+		}
+
+		delete(s.entries, getUsageKey(appId, pid))
+	}
+
+	delete(s.containerToMetadata, getUsageMetadataKey(appId))
+
+	return nil
+}
+
+// Get resource usage metadata of an appId
+func (s *UsageService) getUsageMetadata(appId *big.Int) (*UsageMetadata, bool) {
+	usageMetadataKey := getUsageMetadataKey(appId)
+	usageMetadata, exist := s.containerToMetadata[usageMetadataKey]
+
+	return usageMetadata, exist
+}
+
+// Update resource usage metadata of an appId
+func (s *UsageService) updateUsageMetadata(appId *big.Int, usageMetadata *pbapp.ResourceUsageMetadata) {
+	usageMetadataKey := getUsageMetadataKey(appId)
+	s.containerToMetadata[usageMetadataKey] = usageMetadata
+}
+
+// Get resource usage created by a pid of an appId from memory
+func (s *UsageService) getUsage(appId *big.Int, pid uint32) (*UsageEntry, bool) {
+	resourceUsageKey := getUsageKey(appId, pid)
+	usage, exist := s.entries[resourceUsageKey]
+
+	return usage, exist
+}
+
+// Update resource usage created by a specific pid for appId
+func (s *UsageService) updateUsage(appId *big.Int, pid uint32, usage *ResourceUsage) {
+	resourceUsageKey := getUsageKey(appId, pid)
+	s.entries[resourceUsageKey] = usage
+}
+
+// Get key to retrieve resource usage created by a pid which had run appId
+func getUsageKey(appId *big.Int, pid uint32) string {
+	return fmt.Sprintf("%s-%s-%d", RESOURCE_USAGE_KEY, appId.String(), pid)
 }
 
 // Get key to retrieve resource usage metadata of an appId
-func getUsageMetadataKey(appId *big.Int) datastore.Key {
-	return datastore.NewKey(fmt.Sprintf("%s-%s", RESOURCE_USAGE_KEY, appId.String()))
-}
-
-// Check if an `appId` already has an usage metadata or not
-func (s *Service) hasUsageMetadata(ctx context.Context, appId *big.Int) (bool, error) {
-	usageMetadataKey := getUsageMetadataKey(appId)
-	hasUsageMetadata, err := s.Datastore.Has(ctx, usageMetadataKey)
-
-	if err != nil {
-		return false, fmt.Errorf("failed to check usage metadata for appId %s: %w", appId.String(), err)
-	}
-
-	return hasUsageMetadata, nil
+func getUsageMetadataKey(appId *big.Int) string {
+	return fmt.Sprintf("%s-%s", RESOURCE_USAGE_KEY, appId.String())
 }


### PR DESCRIPTION
This merge request introduces a comprehensive implementation of the Cache resource usage` for caching usage used by all running containers on the node.

### Enhancements:  
- Save tracked resource usage from all containers into memory instead of datastore
- Use `providerId` instead of old `subnetId`

### Next Steps:  
- Integrate automated tests for app lifecycle scenarios.  

### Notes:  
- The service is designed to align with the existing subnet node architecture and leverages `containerd` and `go-ethereum` libraries for container and Ethereum operations.  

Please review the implementation and provide feedback or suggestions for improvements. 