### PR TITLE
Fix: unable to report usage (WIP)

### DIFF
--- a/core/account/service.go
+++ b/core/account/service.go
@@ -229,11 +229,12 @@ func (account *AccountService) Sign(hash []byte) ([]byte, error) {
 	}
 
 	// Ensure `s` is in the lower half-order
-	halfOrder := new(big.Int).Rsh(crypto.S256().Params().N, 1)
+	curve := account.privateKey.Curve
+	halfOrder := new(big.Int).Rsh(curve.Params().N, 1)
 	v := byte(27)
 	if s.Cmp(halfOrder) > 0 {
-		s.Sub(crypto.S256().Params().N, s)
-		v = 28
+		s = new(big.Int).Sub(curve.Params().N, s)
+		v = byte(28)
 	}
 
 	// Format signature: r (32 bytes) || s (32 bytes) || v (1 byte)

--- a/core/apps/claim_reward.go
+++ b/core/apps/claim_reward.go
@@ -212,7 +212,7 @@ func (s *Service) ConvertUsageToTypedData(usage *ResourceUsage) (*TypedData, err
 			},
 		},
 		Domain: TypedDataDomain{
-			Name:              "SubnetAppStore",
+			Name:              "SubnetAppRegistry",
 			Version:           "1",
 			ChainId:           &chainID,
 			VerifyingContract: s.accountService.AppStoreAddr(),

--- a/core/apps/registry.go
+++ b/core/apps/registry.go
@@ -18,7 +18,7 @@ func (s *Service) ReportUsage(ctx context.Context, appId, usedCpu, usedGpu, used
 	}
 
 	// Call the ClaimReward function from the ABI
-	tx, err := s.accountService.AppStore().ReportUsage(key, providerId, appId, usedCpu, usedGpu, usedMemory, usedStorage, usedUploadBytes, usedDownloadBytes, duration, signature)
+	tx, err := s.accountService.AppStore().ReportUsage(key, appId, providerId, usedCpu, usedGpu, usedMemory, usedStorage, usedUploadBytes, usedDownloadBytes, duration, signature)
 	if err != nil {
 		return common.Hash{}, err
 	}


### PR DESCRIPTION
This merge request fixes the problem of being unable to report usage. 

### Problem
When the provider calls `reportUsage` to `SubnetAppStore`, the result always returns `execution reverted` without additional information.

### Enhancements:  
- Update domain name to the same as the one on the smart contract
- Correct the parameter orders when the provider calls `reportUsage`
- Try updating the signing function

### Next Steps:  
- Find a way to debug in smart contract 

Please review the implementation and provide feedback or suggestions for improvements. 