### PR TITLE
Develop

### DIFF
--- a/config/default_config.go
+++ b/config/default_config.go
@@ -1,6 +1,6 @@
 package config
 
 const DefaultRPC = "https://rpc-nebulas-testnet.u2u.xyz"
-const DefaultSubnetAppStoreAddr = "0xaa0Dce508602d0eF4E1501F4C0eA6cBDD3b8018F"
-const DefaultSubnetProviderAddr = "0x3D99fd0A0423a0d3E6808d7726b12f4854B57C6D"
-const DefaultSubnetVerifier = "0x837Cd3C2E6780dd22A9eaFb75f656B3349CC7050"
+const DefaultSubnetAppStoreAddr = "0x5F49358D7717D001Cd5B8bF5613b9bc14cE3dBd2"
+const DefaultSubnetProviderAddr = "0x251240b2Cfbb877Da294893939A8fCaACB414273"
+const DefaultSubnetVerifier = "0x50a734427B851aec24F28326818B869ec83D1732"

--- a/config/default_config.go
+++ b/config/default_config.go
@@ -1,6 +1,6 @@
 package config
 
-const DefaultRPC = "https://rpc-nebulas-testnet.u2u.xyz"
+const DefaultRPC = "https://rpc-mainnet.u2u.xyz"
 const DefaultSubnetAppStoreAddr = "0x5F49358D7717D001Cd5B8bF5613b9bc14cE3dBd2"
 const DefaultSubnetProviderAddr = "0x251240b2Cfbb877Da294893939A8fCaACB414273"
 const DefaultSubnetVerifier = "0x50a734427B851aec24F28326818B869ec83D1732"


### PR DESCRIPTION
This pull request includes several updates to the configuration and verifier processing logic. The most important changes involve updating the default configuration values and enhancing the verification process to handle logs from multiple providers.

Configuration updates:

* [`config/default_config.go`](diffhunk://#diff-3704362a207a501cee70cf7630ffa945f46a36ef27718b2497d521f89c6d2620L3-R6): Updated the default RPC URL and addresses for `DefaultSubnetAppStoreAddr`, `DefaultSubnetProviderAddr`, and `DefaultSubnetVerifier` to point to the mainnet instead of the testnet.

Enhancements to verifier processing:

* [`core/apps/verifier/verifier.go`](diffhunk://#diff-e4dda19f3188ee657ed467b40fd42a6f11a41e485e3a3665c626d17e6208355aL262-R273): Added a check in the `processUsageReports` function to skip signing logs from peers if the logs come from multiple providers, ensuring the integrity of the usage reports.
* [`core/apps/verifier/verifier.go`](diffhunk://#diff-e4dda19f3188ee657ed467b40fd42a6f11a41e485e3a3665c626d17e6208355aR240): Added a new line for better readability in the `processUsageReports` function.