### PR TITLE
Develop

### DIFF
--- a/core/apps/app_report.go
+++ b/core/apps/app_report.go
@@ -25,6 +25,7 @@ func (s *Service) startReportLoop(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			log.Infof("Starting report for all running containers...")
+			time.Sleep(1 * time.Second)
 			s.reportAllRunningContainers(ctx)
 		case <-s.stopChan:
 			log.Infof("Stopping report for all containers")

--- a/core/apps/verifier/verifier.go
+++ b/core/apps/verifier/verifier.go
@@ -146,7 +146,7 @@ func (v *Verifier) onUsageReport(s network.Stream) {
 	}
 
 	if msg.Timestamp-previousReportTime.(int64) < int64(ReportTimeThreshold.Seconds()) {
-		log.Warnf("Previous timestamp validation failed: previous report time %d is less than %s", previousReportTime, ReportTimeThreshold)
+		log.Warnf("Previous timestamp validation failed: previous report time %d is less than %s. Current report time: %d", previousReportTime, ReportTimeThreshold, msg.Timestamp)
 		return
 	}
 


### PR DESCRIPTION
This pull request includes minor changes to improve logging and add a delay in the report loop.

Logging improvements:

* [`core/apps/verifier/verifier.go`](diffhunk://#diff-e4dda19f3188ee657ed467b40fd42a6f11a41e485e3a3665c626d17e6208355aL149-R149): Enhanced the log message in `func (v *Verifier) onUsageReport(s network.Stream)` to include the current report time for better debugging.

Report loop modification:

* [`core/apps/app_report.go`](diffhunk://#diff-06c07e05a5fabd17e8ce770a27bfda4d03ce031abafe33b9b9dddd9d1939c2c0R28): Added a 1-second sleep in the `func (s *Service) startReportLoop(ctx context.Context)` to prevent immediate execution of the report function.