### PR TITLE
add more bootnode

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -69,6 +69,7 @@ func InitWithIdentity(identity Identity) (map[interface{}]interface{}, error) {
 		},
 		"bootstrap": []interface{}{
 			"/ip4/47.129.250.9/tcp/4001/p2p/12D3KooWDK63y6sxFi3dNqrS8yRetgbB81Tzszvs2yLoEtWtPCDa",
+			"/ip4/54.255.247.224/tcp/4001/p2p/12D3KooWQT4FPJiYSSRNk8qaWhHVSxAFmKzuCwDAJskZpxUnhcd2",
 		},
 	}, nil
 }

--- a/core/apps/service.go
+++ b/core/apps/service.go
@@ -131,8 +131,10 @@ func (s *Service) Stop(ctx context.Context) error {
 		}
 	}
 
-	// Close sub-services
-	s.statService.Stop()
+	if s.statService != nil {
+		// Close sub-services
+		s.statService.Stop()
+	}
 
 	close(s.signatureResponseChan)
 


### PR DESCRIPTION
This pull request includes an update to the `cmd/init/init.go` file to add a new bootstrap node to the list of bootstrap addresses.

Network configuration update:

* [`cmd/init/init.go`](diffhunk://#diff-565fe7b054ae8b4bbc9b55e0b8729cc5a4240ed6a86a688e7588a6fde8669b91R72): Added a new bootstrap node with the address `/ip4/54.255.247.224/tcp/4001/p2p/12D3KooWQT4FPJiYSSRNk8qaWhHVSxAFmKzuCwDAJskZpxUnhcd2` to the `bootstrap` list in the `InitWithIdentity` function.