### PR TITLE
Refactor PoW implementation to include peerID in data

### DIFF
--- a/core/apps/verifier/pow.go
+++ b/core/apps/verifier/pow.go
@@ -66,7 +66,7 @@ func NewPow(nodeType NodeType, ps p2phost.Host, P2P *p2p.P2P) *Pow {
 }
 
 // PerformPoW performs the Proof of Work by finding a nonce that satisfies the difficulty using multiple CPUs
-func (p *Pow) performPoW(data string, difficulty int) (string, int) {
+func (p *Pow) performPoW(data, peerID string, difficulty int) (string, int) {
 	var wg sync.WaitGroup
 	numCPU := runtime.NumCPU()
 	targetPrefix := strings.Repeat("0", difficulty)
@@ -87,7 +87,7 @@ func (p *Pow) performPoW(data string, difficulty int) (string, int) {
 				case <-stopChan:
 					return
 				default:
-					input := fmt.Sprintf("%s:%d", data, nonce)
+					input := fmt.Sprintf("%s:%s:%d", data, peerID, nonce)
 					hash := sha256.Sum256([]byte(input))
 					hashHex := hex.EncodeToString(hash[:])
 
@@ -118,8 +118,8 @@ func (p *Pow) performPoW(data string, difficulty int) (string, int) {
 }
 
 // VerifyPoW verifies the Proof of Work by checking the hash and nonce
-func (p *Pow) verifyPoW(data string, nonce int, hash string, difficulty int) bool {
-	input := fmt.Sprintf("%s:%d", data, nonce)
+func (p *Pow) verifyPoW(data, peerID string, nonce int, hash string, difficulty int) bool {
+	input := fmt.Sprintf("%s:%s:%d", data, peerID, nonce)
 	expectedHash := sha256.Sum256([]byte(input))
 	expectedHashHex := hex.EncodeToString(expectedHash[:])
 	targetPrefix := strings.Repeat("0", int(difficulty))
@@ -192,7 +192,7 @@ func (p *Pow) OnPoWResponse(s network.Stream) {
 	expectedMaxPoWTime := time.Duration(msg.Nonce/5000)*time.Millisecond + 500*time.Millisecond // Adjust this based on your requirements
 	log.Infof("Received PoW response from %s. Duration: %s, Nonce: %d, Hash: %s, Expected Max Time: %s", peerID, duration, msg.Nonce, msg.Hash, expectedMaxPoWTime)
 	// Verify PoW
-	if p.verifyPoW(msg.Id, int(msg.Nonce), msg.Hash, 6) {
+	if p.verifyPoW(msg.Id, peerID, int(msg.Nonce), msg.Hash, 6) {
 		if duration <= expectedMaxPoWTime {
 			log.Infof("PoW verified successfully for peer %s", peerID)
 			p.qualifiedPeers[peerID] = true
@@ -231,7 +231,7 @@ func (p *Pow) OnPoWRequest(s network.Stream) {
 
 	log.Infof("Received PoW request from %s. Data: %s, Difficulty: %d", s.Conn().RemotePeer(), msg.Id, msg.Difficulty)
 
-	hash, nonce := p.performPoW(msg.Id, int(msg.Difficulty))
+	hash, nonce := p.performPoW(msg.Id, peerID, int(msg.Difficulty))
 
 	response := &pvtypes.PowResponse{
 		Id:    msg.Id,

--- a/core/apps/verifier/pow.go
+++ b/core/apps/verifier/pow.go
@@ -192,7 +192,7 @@ func (p *Pow) OnPoWResponse(s network.Stream) {
 	expectedMaxPoWTime := time.Duration(msg.Nonce/5000)*time.Millisecond + 500*time.Millisecond // Adjust this based on your requirements
 	log.Infof("Received PoW response from %s. Duration: %s, Nonce: %d, Hash: %s, Expected Max Time: %s", peerID, duration, msg.Nonce, msg.Hash, expectedMaxPoWTime)
 	// Verify PoW
-	if p.verifyPoW(msg.Id, peerID, int(msg.Nonce), msg.Hash, 6) {
+	if p.verifyPoW(msg.Id, p.ps.ID().String(), int(msg.Nonce), msg.Hash, 6) {
 		if duration <= expectedMaxPoWTime {
 			log.Infof("PoW verified successfully for peer %s", peerID)
 			p.qualifiedPeers[peerID] = true

--- a/core/apps/verifier/pow_test.go
+++ b/core/apps/verifier/pow_test.go
@@ -9,28 +9,30 @@ import (
 
 func TestPerformPoW(t *testing.T) {
 	pow := &Pow{}
-	data := "test" // Generate test data using UUID
+	data := "test"
+	peerID := uuid.New().String() // Generate test peerID using UUID
 	difficulty := 2
 
-	hash, nonce := pow.performPoW(data, difficulty)
+	hash, nonce := pow.performPoW(data, peerID, difficulty)
 
 	assert.NotEmpty(t, hash, "Hash should not be empty")
 	assert.GreaterOrEqual(t, nonce, 0, "Nonce should be greater than or equal to 0")
-	assert.True(t, pow.verifyPoW(data, nonce, hash, difficulty), "PoW verification should pass")
+	assert.True(t, pow.verifyPoW(data, peerID, nonce, hash, difficulty), "PoW verification should pass")
 }
 
 func TestVerifyPoW(t *testing.T) {
 	pow := &Pow{}
-	data := uuid.New().String() // Generate test data using UUID
+	data := uuid.New().String()   // Generate test data using UUID
+	peerID := uuid.New().String() // Generate test peerID using UUID
 	difficulty := 2
 
-	hash, nonce := pow.performPoW(data, difficulty)
+	hash, nonce := pow.performPoW(data, peerID, difficulty)
 
-	assert.True(t, pow.verifyPoW(data, nonce, hash, difficulty), "PoW verification should pass")
+	assert.True(t, pow.verifyPoW(data, peerID, nonce, hash, difficulty), "PoW verification should pass")
 
 	// Test with incorrect nonce
-	assert.False(t, pow.verifyPoW(data, nonce+1, hash, difficulty), "PoW verification should fail with incorrect nonce")
+	assert.False(t, pow.verifyPoW(data, peerID, nonce+1, hash, difficulty), "PoW verification should fail with incorrect nonce")
 
 	// Test with incorrect hash
-	assert.False(t, pow.verifyPoW(data, nonce, "incorrecthash", difficulty), "PoW verification should fail with incorrect hash")
+	assert.False(t, pow.verifyPoW(data, peerID, nonce, "incorrecthash", difficulty), "PoW verification should fail with incorrect hash")
 }


### PR DESCRIPTION
This pull request introduces changes to the Proof of Work (PoW) implementation in the `core/apps/verifier/pow.go` file to include the `peerID` in the PoW process. This ensures that the PoW is tied to a specific peer, enhancing security and traceability. Additionally, corresponding updates are made to the test cases in the `core/apps/verifier/pow_test.go` file.

Key changes include:

### Proof of Work Enhancements:
* Modified `performPoW` to include `peerID` as a parameter, updating the input format to include the `peerID` in the hash calculation. (`core/apps/verifier/pow.go`, [[1]](diffhunk://#diff-1428c06e259930d87d731820ccd9a02c25d614dbfe973c944be7ad33e92c428cL69-R69) [[2]](diffhunk://#diff-1428c06e259930d87d731820ccd9a02c25d614dbfe973c944be7ad33e92c428cL90-R90)
* Updated `verifyPoW` to include `peerID` as a parameter, ensuring the verification process checks the hash with the `peerID`. (`core/apps/verifier/pow.go`, [core/apps/verifier/pow.goL121-R122](diffhunk://#diff-1428c06e259930d87d731820ccd9a02c25d614dbfe973c944be7ad33e92c428cL121-R122))

### PoW Request and Response Handling:
* Adjusted `OnPoWRequest` and `OnPoWResponse` methods to pass `peerID` when calling `performPoW` and `verifyPoW`. (`core/apps/verifier/pow.go`, [[1]](diffhunk://#diff-1428c06e259930d87d731820ccd9a02c25d614dbfe973c944be7ad33e92c428cL195-R195) [[2]](diffhunk://#diff-1428c06e259930d87d731820ccd9a02c25d614dbfe973c944be7ad33e92c428cL234-R234)

### Test Case Updates:
* Updated test cases in `pow_test.go` to include `peerID` in both `performPoW` and `verifyPoW` calls, ensuring tests validate the new behavior. (`core/apps/verifier/pow_test.go`, [core/apps/verifier/pow_test.goL12-R37](diffhunk://#diff-9d136807dabc4529a85b8d255d3575ea9d5e7598e43c7da2244fd0fd21db2fbcL12-R37))