### PR TITLE
Update service.go

### DIFF
--- a/core/account/service.go
+++ b/core/account/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -67,8 +68,6 @@ func NewAccountService(cfg *config.C) (*AccountService, error) {
 		return nil, err
 	}
 
-	providerId := int64(cfg.GetInt("provider.id", 0))
-
 	s := &AccountService{
 		privateKey:         privateKey,
 		client:             client,
@@ -77,8 +76,8 @@ func NewAccountService(cfg *config.C) (*AccountService, error) {
 		subnetProviderAddr: subnetProviderAddr,
 		subnetAppStore:     subnetAppStore,
 		subnetAppStoreAddr: subnetAppStoreAddr,
-		providerID:         providerId,
 	}
+	s.updateProviderID(cfg)
 	s.registerReloadCallback(cfg)
 	return s, nil
 }
@@ -96,9 +95,16 @@ func (s *AccountService) registerReloadCallback(cfg *config.C) {
 		}
 
 		if cfg.HasChanged("provider.id") {
-			s.providerID = int64(cfg.GetInt("provider.id", 0))
+			s.updateProviderID(cfg)
 		}
 	})
+}
+
+func (s *AccountService) updateProviderID(cfg *config.C) {
+	providerIdHex := cfg.GetString("provider.id", "")
+	if providerIdHex != "" {
+		s.providerID = int64(hexutil.MustDecodeUint64(providerIdHex))
+	}
 }
 
 // GetClient retrieves the ethclient instance


### PR DESCRIPTION
This pull request includes several changes to the `core/account/service.go` file, focusing on refactoring the handling of the `provider.id` configuration and adding a new import for hex utility functions.

Refactoring and configuration handling:

* [`core/account/service.go`](diffhunk://#diff-d07f5495685692bf898b9a61ce4bdfdc03adfbeff02e9fd44da72308e30b901bL70-L71): Removed direct assignment of `providerID` and replaced it with a call to a new `updateProviderID` method in the `NewAccountService` constructor. [[1]](diffhunk://#diff-d07f5495685692bf898b9a61ce4bdfdc03adfbeff02e9fd44da72308e30b901bL70-L71) [[2]](diffhunk://#diff-d07f5495685692bf898b9a61ce4bdfdc03adfbeff02e9fd44da72308e30b901bL80-R80)
* [`core/account/service.go`](diffhunk://#diff-d07f5495685692bf898b9a61ce4bdfdc03adfbeff02e9fd44da72308e30b901bL99-R109): Updated the `registerReloadCallback` method to use the new `updateProviderID` method instead of directly assigning `providerID`.
* [`core/account/service.go`](diffhunk://#diff-d07f5495685692bf898b9a61ce4bdfdc03adfbeff02e9fd44da72308e30b901bL99-R109): Added a new method `updateProviderID` to handle the conversion of the `provider.id` from a hex string to an integer.

Imports:

* [`core/account/service.go`](diffhunk://#diff-d07f5495685692bf898b9a61ce4bdfdc03adfbeff02e9fd44da72308e30b901bR11): Added a new import for `github.com/ethereum/go-ethereum/common/hexutil` to support the hex string conversion in the `updateProviderID` method.