### PR TITLE
Add public API for version information

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
             OS=${PLATFORM%/*}
             ARCH=${PLATFORM#*/}
             OUTPUT="dist/${NAME}-${VERSION}-${OS}-${ARCH}"
-            GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -o $OUTPUT ./cmd/subnet/main.go
+            GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -ldflags "-X 'github.com/unicornultrafoundation/subnet-node.CurrentCommit=$(git rev-parse HEAD)' -X 'github.com/unicornultrafoundation/subnet-node.CurrentVersionNumber=${VERSION}'" -o $OUTPUT ./cmd/subnet/main.go
           done
 
       - name: Upload Linux Artifacts

--- a/core/corehttp/api.go
+++ b/core/corehttp/api.go
@@ -30,6 +30,13 @@ func APIOption() ServeOption {
 		server.RegisterName("app", api.NewAppAPI(n.Apps))
 		server.RegisterName("account", api.NewAccountAPI(n.Account))
 		server.RegisterName("config", api.NewConfigAPI(n.Repo))
+		server.RegisterName("version", api.NewVersionAPI()) // Register the VersionAPI
+
+		// Handle public APIs without authentication
+		publicServer := rpc.NewServer()
+		publicServer.RegisterName("version", api.NewVersionAPI())
+		smux.Handle("/public", publicServer)
+
 		smux.Handle(APIPath, WithCORSHeaders(cfg, WithAuth(cfg, server)))
 		return smux, nil
 	}

--- a/core/corehttp/api.go
+++ b/core/corehttp/api.go
@@ -35,7 +35,7 @@ func APIOption() ServeOption {
 		// Handle public APIs without authentication
 		publicServer := rpc.NewServer()
 		publicServer.RegisterName("version", api.NewVersionAPI())
-		smux.Handle("/public", publicServer)
+		smux.Handle("/public", WithCORSHeaders(cfg, publicServer))
 
 		smux.Handle(APIPath, WithCORSHeaders(cfg, WithAuth(cfg, server)))
 		return smux, nil

--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"context"
+
+	version "github.com/unicornultrafoundation/subnet-node"
+)
+
+type VersionAPI struct{}
+
+func NewVersionAPI() *VersionAPI {
+	return &VersionAPI{}
+}
+
+func (api *VersionAPI) GetVersion(ctx context.Context) (*version.VersionInfo, error) {
+	return version.GetVersionInfo(), nil
+}

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal.
-const CurrentVersionNumber = "0.0.1-dev"
+const CurrentVersionNumber = "v1.0.1"
 
 const ApiVersion = "/subnet/" + CurrentVersionNumber + "/" //nolint
 
@@ -31,10 +31,10 @@ func SetUserAgentSuffix(suffix string) {
 }
 
 type VersionInfo struct {
-	Version string
-	Commit  string
-	System  string
-	Golang  string
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	System  string `json:"system"`
+	Golang  string `json:"golang"`
 }
 
 func GetVersionInfo() *VersionInfo {

--- a/version.go
+++ b/version.go
@@ -8,9 +8,9 @@ import (
 var CurrentCommit string
 
 // CurrentVersionNumber is the current application's version literal.
-const CurrentVersionNumber = "v1.0.1"
+var CurrentVersionNumber string
 
-const ApiVersion = "/subnet/" + CurrentVersionNumber + "/" //nolint
+var ApiVersion = "/subnet/" + CurrentVersionNumber + "/" //nolint
 
 // Note: This will end in `/` when no commit is available. This is expected.
 func GetUserAgentVersion() string {
@@ -41,7 +41,7 @@ func GetVersionInfo() *VersionInfo {
 	return &VersionInfo{
 		Version: CurrentVersionNumber,
 		Commit:  CurrentCommit,
-		System:  runtime.GOARCH + "/" + runtime.GOOS, // TODO: Precise version here
+		System:  runtime.GOARCH + "/" + runtime.GOOS,
 		Golang:  runtime.Version(),
 	}
 }


### PR DESCRIPTION
This pull request introduces a new `VersionAPI` to the project, updates the version number, and modifies the `VersionInfo` struct to include JSON tags. The most important changes are grouped into API enhancements and version updates.

API enhancements:

* [`core/corehttp/api.go`](diffhunk://#diff-108847c59dfb833f203e58e60a4a31122d46c9221d3dd2b08ef968125a77d4f8R33-R39): Registered the new `VersionAPI` and added a public server to handle unauthenticated requests to the version endpoint.
* [`internal/api/version.go`](diffhunk://#diff-6f9238e239f066b33acc6bef4b00ef23bf6a0b7571a47c30e3c8c0d839aed205R1-R17): Added a new `VersionAPI` to provide version information through a new API endpoint.

Version updates:

* [`version.go`](diffhunk://#diff-1ef170619a70876f007d5edfc4554a81aa686eae7678b70df0347b3133cd6d14L11-R11): Updated the `CurrentVersionNumber` from "0.0.1-dev" to "v1.0.1".
* [`version.go`](diffhunk://#diff-1ef170619a70876f007d5edfc4554a81aa686eae7678b70df0347b3133cd6d14L34-R37): Modified the `VersionInfo` struct to include JSON tags for the fields `version`, `commit`, `system`, and `golang`.